### PR TITLE
docs: fix simple typo, initalized -> initialized

### DIFF
--- a/hebel/layers/hidden_layer.py
+++ b/hebel/layers/hidden_layer.py
@@ -53,7 +53,7 @@ class HiddenLayer(object):
 
     parameters : array_like of ``GPUArray``
         Parameters used to initialize the layer. If this is omitted,
-        then the weights are initalized randomly using *Bengio's rule*
+        then the weights are initialized randomly using *Bengio's rule*
         (uniform distribution with scale :math:`4 \cdot \sqrt{6 /
         (\mathtt{n\_in} + \mathtt{n\_out})}` if using sigmoid
         activations and :math:`\sqrt{6 / (\mathtt{n\_in} +

--- a/hebel/layers/linear_regression_layer.py
+++ b/hebel/layers/linear_regression_layer.py
@@ -38,7 +38,7 @@ class LinearRegressionLayer(SoftmaxLayer):
 
     parameters : array_like of ``GPUArray``
         Parameters used to initialize the layer. If this is omitted,
-        then the weights are initalized randomly using *Bengio's rule*
+        then the weights are initialized randomly using *Bengio's rule*
         (uniform distribution with scale :math:`4 \cdot \sqrt{6 /
         (\mathtt{n\_in} + \mathtt{n\_out})}`) and the biases are
         initialized to zero. If ``parameters`` is given, then is must

--- a/hebel/layers/logistic_layer.py
+++ b/hebel/layers/logistic_layer.py
@@ -39,7 +39,7 @@ class LogisticLayer(TopLayer):
 
     parameters : array_like of ``GPUArray``
         Parameters used to initialize the layer. If this is omitted,
-        then the weights are initalized randomly using *Bengio's rule*
+        then the weights are initialized randomly using *Bengio's rule*
         (uniform distribution with scale :math:`4 \cdot \sqrt{6 /
         (\mathtt{n\_in} + \mathtt{n\_out})}`) and the biases are
         initialized to zero. If ``parameters`` is given, then is must

--- a/hebel/layers/softmax_layer.py
+++ b/hebel/layers/softmax_layer.py
@@ -42,7 +42,7 @@ class SoftmaxLayer(TopLayer):
 
     parameters : array_like of ``GPUArray``
         Parameters used to initialize the layer. If this is omitted,
-        then the weights are initalized randomly using *Bengio's rule*
+        then the weights are initialized randomly using *Bengio's rule*
         (uniform distribution with scale :math:`4 \cdot \sqrt{6 /
         (\mathtt{n\_in} + \mathtt{n\_out})}`) and the biases are
         initialized to zero. If ``parameters`` is given, then is must


### PR DESCRIPTION
There is a small typo in hebel/layers/hidden_layer.py, hebel/layers/linear_regression_layer.py, hebel/layers/logistic_layer.py, hebel/layers/softmax_layer.py.

Should read `initialized` rather than `initalized`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md